### PR TITLE
8302789: (fs) File.copy should include unsupported copy option in exception message

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,7 +474,7 @@ abstract class UnixFileSystem
                 }
                 if (option == null)
                     throw new NullPointerException();
-                throw new UnsupportedOperationException("Unsupported copy option");
+                throw new UnsupportedOperationException("Unsupported copy option: " + option);
             }
             return flags;
         }
@@ -496,7 +496,7 @@ abstract class UnixFileSystem
                 }
                 if (option == null)
                     throw new NullPointerException();
-                throw new UnsupportedOperationException("Unsupported copy option");
+                throw new UnsupportedOperationException("Unsupported option: " + option);
             }
 
             // a move requires that all attributes be copied but only fail if

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -301,7 +301,7 @@ class WindowsFileCopy {
                 continue;
             }
             if (option == null) throw new NullPointerException();
-            throw new UnsupportedOperationException("Unsupported move option: " + option);
+            throw new UnsupportedOperationException("Unsupported option: " + option);
         }
 
         @SuppressWarnings("removal")

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -81,7 +81,7 @@ class WindowsFileCopy {
             }
             if (option == null)
                 throw new NullPointerException();
-            throw new UnsupportedOperationException("Unsupported copy option");
+            throw new UnsupportedOperationException("Unsupported copy option: " + option);
         }
 
         // check permissions. If the source file is a symbolic link then
@@ -301,7 +301,7 @@ class WindowsFileCopy {
                 continue;
             }
             if (option == null) throw new NullPointerException();
-            throw new UnsupportedOperationException("Unsupported copy option");
+            throw new UnsupportedOperationException("Unsupported move option: " + option);
         }
 
         @SuppressWarnings("removal")


### PR DESCRIPTION
This PR also fixes the exception message for unsupported move options.