### PR TITLE
8313155: Problem list some JUnit-based tests in test/jdk/java/lang/invoke

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -478,6 +478,8 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
+java/lang/invoke/MethodHandleProxies/BasicTest.java              8313155 linux-all
+java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java 8313155 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Problem list some JUnit-based tests in test/jdk/java/lang/invoke for the time being - until `jtreg 7.3` with a fix the underlying race condition is released.